### PR TITLE
use CCI env var context for GH token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,10 @@ jobs:
   deploy:
     executor: java
     steps:
-      - add_ssh_keys
       - checkout
       - cacheit
+      - run: |
+          git config --global url."https://${GITHUB_TOKEN}:@github.com/".insteadOf git@github.com:
       - run: git clone git@github.com:librato/ci-scripts.git ci-scripts
       - run:
           name: Deploy snapshot
@@ -64,9 +65,10 @@ jobs:
     executor: java
 
     steps:
-      - add_ssh_keys
       - checkout
       - cacheit
+      - run: |
+          git config --global url."https://${GITHUB_TOKEN}:@github.com/".insteadOf git@github.com:
       - run: git clone git@github.com:librato/ci-scripts.git ci-scripts
       - run:
           name: Check versions
@@ -110,14 +112,18 @@ workflows:
       - build:
           context: org-global
       - deploy:
-          context: org-global
+          context:
+            - org-global
+            - GH_LIBRATO_CI_REPO
           requires:
             - build
           filters:
             branches:
               ignore: master
       - release:
-          context: org-global
+          context:
+            - org-global
+            - GH_LIBRATO_CI_REPO
           filters:
             branches:
               only: master


### PR DESCRIPTION
@danielchemko I noticed this build pop-up in CircleCI today . . . I'm in the middle of doing a bunch of clean-up of various keys/credentials we have stored in CircleCI so I decided to take a look.

One of the things we're trying to steer people away from is the use of project-level secrets and SSH keys. We're trying to centralize all of the creds in CCI contexts that can be re-used across projects.

I add a line in here which should get you past the issue your build was having while trying to clone the `ci-scripts` repo.

You're welcome to merge this PR (or just close it if it's not gonna help). Feel free to reach out if I can be of any help.