### PR TITLE
SP-2583 Zookeeper name resolver fix #2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-server/target/lib/zookeeper-server-$NEW_VERSION.jar \
+              -Dfile=zookeeper-server/target/zookeeper-server-$NEW_VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 
@@ -109,7 +109,7 @@ jobs:
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-server/target/lib/zookeeper-server-$VERSION.jar \
+              -Dfile=zookeeper-server/target/zookeeper-server-$VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
               -DpomFile=zookeeper/pom.xml \
-              -Dfile=zookeeper-server/target/zookeeper-server-$NEW_VERSION.jar \
+              -Dfile=zookeeper/target/zookeeper-$VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,13 @@ jobs:
             mvn -s .circleci/m2/settings.xml package -DskipTests
 
             mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
+              -DartifactId=zookeeper-parent \
+              -Dversion=$NEW_VERSION \
+              -Dpackaging=pom \
+              -Dfile=pom.xml \
+              -DrepositoryId=github \
+              -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
@@ -95,8 +102,15 @@ jobs:
             mvn -s .circleci/m2/settings.xml package -DskipTests
 
             mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
+              -DartifactId=zookeeper-parent \
+              -Dversion=$VERSION \
+              -Dpackaging=pom \
+              -Dfile=pom.xml \
+              -DrepositoryId=github \
+              -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
               -DartifactId=zookeeper \
-              -Dversion=$NEW_VERSION \
+              -Dversion=$VERSION \
               -Dpackaging=jar \
               -DpomFile=zookeeper/pom.xml \
               -Dfile=zookeeper/target/zookeeper-$VERSION.jar \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
               -DpomFile=zookeeper/pom.xml \
-              -Dfile=zookeeper/target/zookeeper-$VERSION.jar \
+              -Dfile=zookeeper/target/zookeeper-$NEW_VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,134 @@
+version: 2.1
+
+executors:
+  java:
+    parameters:
+      tag:
+        type: string
+        default: adoptopenjdk12
+    docker:
+      - image: 209556801791.dkr.ecr.us-east-1.amazonaws.com/librato/java-ci:<< parameters.tag >>
+        aws_auth:
+          aws_access_key_id: $LIBRATO_ECR_AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $LIBRATO_ECR_AWS_SECRET_ACCESS_KEY
+    environment:
+      PROJECT_NAME: zookeeper
+      SLACK_NOTIFY_URL: "https://hooks.slack.com/services/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"
+      SLACK_NOTIFY_CHANNEL: "#log-ingestion-notify"
+      EMOJI: ":circle-pass:"
+
+commands:
+  cacheit:
+    steps:
+      - run:
+          name: generate cache checksum
+          command: find . -name pom.xml | sort | xargs -n 1 cat > /tmp/maven_cached_poms
+      - restore_cache:
+          keys:
+            - maven-repo-v1-{{ .Branch }}-{{ checksum "/tmp/maven_cached_poms" }}
+            - maven-repo-v1-{{ .Branch }}-
+            - maven-repo-v1-
+      - run: mvn -q -s .circleci/m2/settings.xml test-compile
+      - save_cache:
+          paths:
+            - ~/.m2/repository
+          key: maven-repo-v1-{{ .Branch }}-{{ checksum "/tmp/maven_cached_poms" }}
+
+jobs:
+  build:
+    executor: java
+    steps:
+      - checkout
+      - cacheit
+
+  deploy:
+    executor: java
+    steps:
+      - checkout
+      - cacheit
+      - run: |
+          git config --global url."https://${GITHUB_TOKEN}:@github.com/".insteadOf git@github.com:
+      - run: git clone git@github.com:librato/ci-scripts.git ci-scripts
+      - run:
+          name: Deploy snapshot
+          command: |
+            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            BRANCH=$(echo -n "${CIRCLE_BRANCH}" | sed -e 's/[^0-9a-zA-Z\._\-]/./g' | tr '[:upper:]' '[:lower:]')
+            NEW_VERSION=${VERSION%%-SNAPSHOT}-$BRANCH-SNAPSHOT
+
+            mvn versions:set -DnewVersion=$NEW_VERSION
+            mvn -s .circleci/m2/settings.xml deploy -DskipTests
+
+            .circleci/notify.sh "A new snapshot is ready \`$NEW_VERSION\`"
+
+  release:
+    executor: java
+
+    steps:
+      - checkout
+      - cacheit
+      - run: |
+          git config --global url."https://${GITHUB_TOKEN}:@github.com/".insteadOf git@github.com:
+      - run: git clone git@github.com:librato/ci-scripts.git ci-scripts
+      - run:
+          name: Check versions
+          command: mvn versions:use-releases
+      - run:
+          name: Configure git for release
+          command: |
+            git config user.name "librato-ci"
+            git config user.email "tools+librato-ci-githublibrato.com"
+      - run:
+          name: Prepare release
+          command: |
+            mvn -s .circleci/m2/settings.xml \
+                --batch-mode \
+                -DscmCommentPrefix="[maven-release-plugin][ci skip] " \
+                -Ddependency-check.skip=true \
+                -DskipTests \
+                -Darguments="-DskipTests -Ddependency-check.skip=true" \
+                release:prepare
+      - run:
+          name: Perform release
+          command: |
+            mvn -s .circleci/m2/settings.xml \
+                --batch-mode \
+                -Ddependency-check.skip=true \
+                -DskipTests \
+                -Darguments="-DskipTests -Ddependency-check.skip=true" \
+                release:perform
+
+            # Go back to the commit before the snapshot
+            git reset --hard HEAD~1
+
+            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            echo "Current version is $VERSION"
+            .circleci/notify.sh "A new release is ready \`$VERSION\`"
+
+workflows:
+  version: 2
+  build_test_release:
+    jobs:
+      - build:
+          context: org-global
+          filters:
+            branches:
+              # Note this will need to be updated any time we need to branch again!
+              only: SP-2583_name_resolver_fix_1
+      - deploy:
+          context:
+            - org-global
+            - GH_LIBRATO_CI_REPO
+          requires:
+            - build
+          filters:
+            branches:
+              # Note this will need to be updated any time we need to branch again!
+              only: SP-2583_name_resolver_fix_1
+      - release:
+          context:
+            - org-global
+            - GH_LIBRATO_CI_REPO
+          filters:
+            branches:
+              only: branch-3.4.14-swi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,14 +57,14 @@ jobs:
             NEW_VERSION=${VERSION%%-SNAPSHOT}-$BRANCH-SNAPSHOT
             mvn versions:set -DnewVersion=$NEW_VERSION
             mvn -s .circleci/m2/settings.xml package -DskipTests
-            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
               -DartifactId=zookeeper-jute \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
               -Dfile=zookeeper-jute/target/zookeeper-jute-$NEW_VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
-            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
@@ -98,14 +98,14 @@ jobs:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn -s .circleci/m2/settings.xml package -DskipTests
-            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
               -DartifactId=zookeeper-jute \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
               -Dfile=zookeeper-jute/target/zookeeper-jute-$VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
-            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,21 @@ jobs:
             NEW_VERSION=${VERSION%%-SNAPSHOT}-$BRANCH-SNAPSHOT
 
             mvn versions:set -DnewVersion=$NEW_VERSION
-            mvn -s .circleci/m2/settings.xml deploy -DskipTests
+            mvn -s .circleci/m2/settings.xml package -DskipTests
+            mvn deploy:deploy-file -DgroupId=org.zookeeper \
+              -DartifactId=zookeeper-jute \
+              -Dversion=$NEW_VERSION \
+              -Dpackaging=jar \
+              -Dfile=zookeeper-jute/target/zookeeper-$VERSION.jar \
+              -DrepositoryId=github \
+              -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
+            mvn deploy:deploy-file -DgroupId=org.zookeeper \
+              -DartifactId=zookeeper \
+              -Dversion=$NEW_VERSION \
+              -Dpackaging=jar \
+              -Dfile=zookeeper-server/target/zookeeper-$VERSION.jar \
+              -DrepositoryId=github \
+              -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 
             .circleci/notify.sh "A new snapshot is ready \`$NEW_VERSION\`"
 
@@ -79,27 +93,25 @@ jobs:
             git config user.name "librato-ci"
             git config user.email "tools+librato-ci-githublibrato.com"
       - run:
-          name: Prepare release
-          command: |
-            mvn -s .circleci/m2/settings.xml \
-                --batch-mode \
-                -DscmCommentPrefix="[maven-release-plugin][ci skip] " \
-                -Ddependency-check.skip=true \
-                -DskipTests \
-                -Darguments="-DskipTests -Ddependency-check.skip=true" \
-                release:prepare
-      - run:
           name: Perform release
           command: |
-            mvn -s .circleci/m2/settings.xml \
-                --batch-mode \
-                -Ddependency-check.skip=true \
-                -DskipTests \
-                -Darguments="-DskipTests -Ddependency-check.skip=true" \
-                release:perform
 
-            # Go back to the commit before the snapshot
-            git reset --hard HEAD~1
+            mvn versions set to release
+
+            mvn deploy:deploy-file -DgroupId=org.zookeeper \
+              -DartifactId=zookeeper-jute \
+              -Dversion=$NEW_VERSION \
+              -Dpackaging=jar \
+              -Dfile=zookeeper-jute/target/zookeeper-$VERSION.jar \
+              -DrepositoryId=github \
+              -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
+            mvn deploy:deploy-file -DgroupId=org.zookeeper \
+              -DartifactId=zookeeper \
+              -Dversion=$NEW_VERSION \
+              -Dpackaging=jar \
+              -Dfile=zookeeper-server/target/zookeeper-$VERSION.jar \
+              -DrepositoryId=github \
+              -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 
             VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
             echo "Current version is $VERSION"
@@ -114,7 +126,7 @@ workflows:
           filters:
             branches:
               # Note this will need to be updated any time we need to branch again!
-              only: SP-2583_name_resolver_fix_1
+              only: SP-2583_name_resolver_fix_2
       - deploy:
           context:
             - org-global
@@ -124,7 +136,7 @@ workflows:
           filters:
             branches:
               # Note this will need to be updated any time we need to branch again!
-              only: SP-2583_name_resolver_fix_1
+              only: SP-2583_name_resolver_fix_2
       - release:
           context:
             - org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/lib/zookeeper-$NEW_VERSION.jar \
+              -Dfile=zookeeper-server/target/lib/zookeeper-server-$NEW_VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 
@@ -109,7 +109,7 @@ jobs:
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/lib/zookeeper-$VERSION.jar \
+              -Dfile=zookeeper-server/target/lib/zookeeper-server-$VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-server/target/zookeeper-$NEW_VERSION.jar \
+              -Dfile=zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/lib/zookeeper-$NEW_VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 
@@ -109,7 +109,7 @@ jobs:
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-server/target/zookeeper-$VERSION.jar \
+              -Dfile=zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/lib/zookeeper-$VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,17 +55,16 @@ jobs:
             VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
             BRANCH=$(echo -n "${CIRCLE_BRANCH}" | sed -e 's/[^0-9a-zA-Z\._\-]/./g' | tr '[:upper:]' '[:lower:]')
             NEW_VERSION=${VERSION%%-SNAPSHOT}-$BRANCH-SNAPSHOT
-
             mvn versions:set -DnewVersion=$NEW_VERSION
             mvn -s .circleci/m2/settings.xml package -DskipTests
-            mvn deploy:deploy-file -DgroupId=org.zookeeper \
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
               -DartifactId=zookeeper-jute \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-jute/target/zookeeper-$VERSION.jar \
+              -Dfile=zookeeper-jute/target/zookeeper-jute-$VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
-            mvn deploy:deploy-file -DgroupId=org.zookeeper \
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
@@ -95,17 +94,20 @@ jobs:
       - run:
           name: Perform release
           command: |
+            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            BRANCH=$(echo -n "${CIRCLE_BRANCH}" | sed -e 's/[^0-9a-zA-Z\._\-]/./g' | tr '[:upper:]' '[:lower:]')
+            NEW_VERSION=${VERSION%%-SNAPSHOT}
+            mvn versions:set -DnewVersion=$NEW_VERSION
 
-            mvn versions set to release
-
-            mvn deploy:deploy-file -DgroupId=org.zookeeper \
+            mvn -s .circleci/m2/settings.xml package -DskipTests
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
               -DartifactId=zookeeper-jute \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-jute/target/zookeeper-$VERSION.jar \
+              -Dfile=zookeeper-jute/target/zookeeper-jute-$VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
-            mvn deploy:deploy-file -DgroupId=org.zookeeper \
+            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,14 +61,14 @@ jobs:
               -DartifactId=zookeeper-jute \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-jute/target/zookeeper-jute-$VERSION.jar \
+              -Dfile=zookeeper-jute/target/zookeeper-jute-$NEW_VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
             mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-server/target/zookeeper-$VERSION.jar \
+              -Dfile=zookeeper-server/target/zookeeper-$NEW_VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 
@@ -95,9 +95,7 @@ jobs:
           name: Perform release
           command: |
             VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-            BRANCH=$(echo -n "${CIRCLE_BRANCH}" | sed -e 's/[^0-9a-zA-Z\._\-]/./g' | tr '[:upper:]' '[:lower:]')
-            NEW_VERSION=${VERSION%%-SNAPSHOT}
-            mvn versions:set -DnewVersion=$NEW_VERSION
+            mvn versions:set -DnewVersion=$VERSION
 
             mvn -s .circleci/m2/settings.xml package -DskipTests
             mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.zookeeper \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,18 +56,14 @@ jobs:
             BRANCH=$(echo -n "${CIRCLE_BRANCH}" | sed -e 's/[^0-9a-zA-Z\._\-]/./g' | tr '[:upper:]' '[:lower:]')
             NEW_VERSION=${VERSION%%-SNAPSHOT}-$BRANCH-SNAPSHOT
             mvn versions:set -DnewVersion=$NEW_VERSION
+
             mvn -s .circleci/m2/settings.xml package -DskipTests
-            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
-              -DartifactId=zookeeper-jute \
-              -Dversion=$NEW_VERSION \
-              -Dpackaging=jar \
-              -Dfile=zookeeper-jute/target/zookeeper-jute-$NEW_VERSION.jar \
-              -DrepositoryId=github \
-              -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
+
             mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
+              -DpomFile=zookeeper/pom.xml \
               -Dfile=zookeeper-server/target/zookeeper-server-$NEW_VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
@@ -95,25 +91,18 @@ jobs:
           name: Perform release
           command: |
             VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-            mvn versions:set -DnewVersion=$VERSION
 
             mvn -s .circleci/m2/settings.xml package -DskipTests
-            mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
-              -DartifactId=zookeeper-jute \
-              -Dversion=$NEW_VERSION \
-              -Dpackaging=jar \
-              -Dfile=zookeeper-jute/target/zookeeper-jute-$VERSION.jar \
-              -DrepositoryId=github \
-              -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
+
             mvn -s .circleci/m2/settings.xml deploy:deploy-file -DgroupId=org.apache.zookeeper \
               -DartifactId=zookeeper \
               -Dversion=$NEW_VERSION \
               -Dpackaging=jar \
-              -Dfile=zookeeper-server/target/zookeeper-server-$VERSION.jar \
+              -DpomFile=zookeeper/pom.xml \
+              -Dfile=zookeeper/target/zookeeper-$VERSION.jar \
               -DrepositoryId=github \
               -Durl=https://maven.pkg.github.com/solarwindscloud/maven-releases
 
-            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
             echo "Current version is $VERSION"
             .circleci/notify.sh "A new release is ready \`$VERSION\`"
 

--- a/.circleci/m2/settings.xml
+++ b/.circleci/m2/settings.xml
@@ -4,10 +4,6 @@
   http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
-            <id>packagecloud-librato</id>
-            <password>${env.PACKAGECLOUD_TOKEN}</password>
-        </server>
-        <server>
             <id>github</id>
             <username>librato-ci</username>
             <password>${env.GITHUB_PACKAGE_READ_TOKEN}</password>

--- a/.circleci/m2/settings.xml
+++ b/.circleci/m2/settings.xml
@@ -1,0 +1,16 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+  http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>packagecloud-librato</id>
+            <password>${env.PACKAGECLOUD_TOKEN}</password>
+        </server>
+        <server>
+            <id>github</id>
+            <username>librato-ci</username>
+            <password>${env.GITHUB_PACKAGE_READ_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/.circleci/notify.sh
+++ b/.circleci/notify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source ci-scripts/bin/helpers.sh
+
+SLACK_USER=java-commons send_to_slack "$1"

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ zookeeper-client/zookeeper-client-c/ltmain.sh
 zookeeper-client/zookeeper-client-c/missing
 zookeeper-server/src/main/java/org/apache/zookeeper/version/Info.java
 zookeeper-server/src/test/resources/data/**/
+zookeeper/dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <!-- no parent resolution -->
   </parent>
   <groupId>org.apache.zookeeper</groupId>
-  <artifactId>zookeeper</artifactId>
+  <artifactId>zookeeper-parent</artifactId>
   <packaging>pom</packaging>
   <version>3.4.14-swi1-SNAPSHOT</version>
   <name>Apache ZooKeeper</name>
@@ -61,6 +61,7 @@
     <module>zookeeper-server</module>
     <module>zookeeper-client</module>
     <module>zookeeper-recipes</module>
+    <module>zookeeper</module>
   </modules>
 
   <scm>
@@ -289,6 +290,23 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper-jute</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper-server</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper-server</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-all</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -262,8 +262,8 @@
 
   <properties>
     <!-- maven properties -->
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <dependency.locations.enabled>false</dependency.locations.enabled>
 
     <surefire-forkcount>1</surefire-forkcount>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <groupId>org.apache.zookeeper</groupId>
   <artifactId>zookeeper</artifactId>
   <packaging>pom</packaging>
-  <version>3.4.14</version>
+  <version>3.4.14-swi1-SNAPSHOT</version>
   <name>Apache ZooKeeper</name>
   <description>
     ZooKeeper is a centralized service for maintaining configuration information, naming,

--- a/zookeeper-client/pom.xml
+++ b/zookeeper-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zookeeper-client/pom.xml
+++ b/zookeeper-client/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>zookeeper-parent</artifactId>
     <version>3.4.14-swi1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>

--- a/zookeeper-client/zookeeper-client-c/pom.xml
+++ b/zookeeper-client/zookeeper-client-c/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-client</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zookeeper-contrib/pom.xml
+++ b/zookeeper-contrib/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-loggraph/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-contrib</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-rest/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-contrib</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
+++ b/zookeeper-contrib/zookeeper-contrib-zooinspector/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-contrib</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-docs/pom.xml
+++ b/zookeeper-docs/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>3.4.14</version>
+        <version>3.4.14-swi1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
   <groupId>org.apache.zookeeper</groupId>
   <artifactId>zookeeper-docs</artifactId>
-  <version>3.4.14</version>
+  <version>3.4.14-swi1-SNAPSHOT</version>
   <name>Apache ZooKeeper - Documentation</name>
   <description>Documentation</description>
 

--- a/zookeeper-docs/pom.xml
+++ b/zookeeper-docs/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.zookeeper</groupId>
-        <artifactId>zookeeper</artifactId>
+        <artifactId>zookeeper-parent</artifactId>
         <version>3.4.14-swi1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>

--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zookeeper-jute/pom.xml
+++ b/zookeeper-jute/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>zookeeper-parent</artifactId>
     <version>3.4.14-swi1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>

--- a/zookeeper-recipes/pom.xml
+++ b/zookeeper-recipes/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>

--- a/zookeeper-recipes/pom.xml
+++ b/zookeeper-recipes/pom.xml
@@ -23,7 +23,7 @@
 
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>zookeeper-parent</artifactId>
     <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 

--- a/zookeeper-recipes/zookeeper-recipes-election/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-election/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-recipes</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-recipes/zookeeper-recipes-election/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-election/pom.xml
@@ -38,12 +38,10 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14-swi1-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-recipes/zookeeper-recipes-lock/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-lock/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-recipes</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-recipes/zookeeper-recipes-queue/pom.xml
+++ b/zookeeper-recipes/zookeeper-recipes-queue/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper-recipes</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zookeeper</groupId>
@@ -43,12 +43,12 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-server</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.zookeeper</groupId>
-    <artifactId>zookeeper</artifactId>
+    <artifactId>zookeeper-parent</artifactId>
     <version>3.4.14-swi1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -53,7 +53,6 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
-      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.zookeeper</groupId>
     <artifactId>zookeeper</artifactId>
-    <version>3.4.14</version>
+    <version>3.4.14-swi1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
-      <version>3.4.14</version>
+      <version>3.4.14-swi1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
@@ -58,6 +58,7 @@ public final class ConnectStringParser {
                 serverAddresses.add(new InetSocketAddress(InetAddress.getByName(host), port));
             } catch (UnknownHostException e) {
                 log.error("Unable to resolve the hostname of the Zookeeper server", e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
@@ -25,12 +25,12 @@ import org.apache.zookeeper.common.PathUtils;
 
 /**
  * A parser for ZooKeeper Client connect strings.
- *
+ * 
  * This class is not meant to be seen or used outside of ZooKeeper itself.
- *
+ * 
  * The chrootPath member should be replaced by a Path object in issue
  * ZOOKEEPER-849.
- *
+ * 
  * @see org.apache.zookeeper.ZooKeeper
  */
 public final class ConnectStringParser {
@@ -41,7 +41,7 @@ public final class ConnectStringParser {
     private final ArrayList<InetSocketAddress> serverAddresses = new ArrayList<InetSocketAddress>();
 
     /**
-     *
+     * 
      * @throws IllegalArgumentException
      *             for an invalid chroot path.
      */

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
@@ -1,21 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.apache.zookeeper.client;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 
 import org.apache.zookeeper.common.PathUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Workaround for Zookeeper defect in JDK-14+
+ * A parser for ZooKeeper Client connect strings.
+ *
+ * This class is not meant to be seen or used outside of ZooKeeper itself.
+ *
+ * The chrootPath member should be replaced by a Path object in issue
+ * ZOOKEEPER-849.
+ *
+ * @see org.apache.zookeeper.ZooKeeper
  */
 public final class ConnectStringParser {
     private static final int DEFAULT_PORT = 2181;
-    private static Logger log = LoggerFactory.getLogger(ConnectStringParser.class);
 
     private final String chrootPath;
 
@@ -54,12 +73,7 @@ public final class ConnectStringParser {
                 }
                 host = host.substring(0, pidx);
             }
-            try {
-                serverAddresses.add(new InetSocketAddress(InetAddress.getByName(host), port));
-            } catch (UnknownHostException e) {
-                log.error("Unable to resolve the hostname of the Zookeeper server", e);
-                throw new RuntimeException(e);
-            }
+            serverAddresses.add(InetSocketAddress.createUnresolved(host, port));
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/ConnectStringParser.java
@@ -1,47 +1,28 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 package org.apache.zookeeper.client;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 
 import org.apache.zookeeper.common.PathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * A parser for ZooKeeper Client connect strings.
- * 
- * This class is not meant to be seen or used outside of ZooKeeper itself.
- * 
- * The chrootPath member should be replaced by a Path object in issue
- * ZOOKEEPER-849.
- * 
- * @see org.apache.zookeeper.ZooKeeper
+ * Workaround for Zookeeper defect in JDK-14+
  */
 public final class ConnectStringParser {
     private static final int DEFAULT_PORT = 2181;
+    private static Logger log = LoggerFactory.getLogger(ConnectStringParser.class);
 
     private final String chrootPath;
 
     private final ArrayList<InetSocketAddress> serverAddresses = new ArrayList<InetSocketAddress>();
 
     /**
-     * 
+     *
      * @throws IllegalArgumentException
      *             for an invalid chroot path.
      */
@@ -73,7 +54,11 @@ public final class ConnectStringParser {
                 }
                 host = host.substring(0, pidx);
             }
-            serverAddresses.add(InetSocketAddress.createUnresolved(host, port));
+            try {
+                serverAddresses.add(new InetSocketAddress(InetAddress.getByName(host), port));
+            } catch (UnknownHostException e) {
+                log.error("Unable to resolve the hostname of the Zookeeper server", e);
+            }
         }
     }
 

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/client/StaticHostProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
+import java.util.Random;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,18 +41,35 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.Public
 public final class StaticHostProvider implements HostProvider {
+
     public interface Resolver {
+
         InetAddress[] getAllByName(String name) throws UnknownHostException;
+
     }
 
-    private static final Logger LOG = LoggerFactory
-            .getLogger(StaticHostProvider.class);
+    private static final Logger LOG = LoggerFactory.getLogger(StaticHostProvider.class);
 
-    private final List<InetSocketAddress> serverAddresses = new ArrayList<InetSocketAddress>(5);
+    private List<InetSocketAddress> serverAddresses = new ArrayList<InetSocketAddress>(5);
 
+    private Random sourceOfRandomness;
     private int lastIndex = -1;
 
     private int currentIndex = -1;
+
+    /**
+     * The following fields are used to migrate clients during reconfiguration
+     */
+    private boolean reconfigMode = false;
+
+    private final List<InetSocketAddress> oldServers = new ArrayList<InetSocketAddress>(5);
+
+    private final List<InetSocketAddress> newServers = new ArrayList<InetSocketAddress>(5);
+
+    private int currentIndexOld = -1;
+    private int currentIndexNew = -1;
+
+    private float pOld, pNew;
 
     private Resolver resolver;
 
@@ -65,115 +82,294 @@ public final class StaticHostProvider implements HostProvider {
      *             if serverAddresses is empty or resolves to an empty list
      */
     public StaticHostProvider(Collection<InetSocketAddress> serverAddresses) {
-        this.resolver = new Resolver() {
+        init(serverAddresses, System.currentTimeMillis() ^ this.hashCode(), new Resolver() {
             @Override
             public InetAddress[] getAllByName(String name) throws UnknownHostException {
                 return InetAddress.getAllByName(name);
             }
-        };
-        init(serverAddresses);
+        });
     }
 
     /**
+     * Constructs a SimpleHostSet.
+     *
      * Introduced for testing purposes. getAllByName() is a static method of InetAddress, therefore cannot be easily mocked.
      * By abstraction of Resolver interface we can easily inject a mocked implementation in tests.
      *
      * @param serverAddresses
-     *            possibly unresolved ZooKeeper server addresses
+     *              possibly unresolved ZooKeeper server addresses
      * @param resolver
-     *            custom resolver implementation
+     *              custom resolver implementation
+     */
+    public StaticHostProvider(Collection<InetSocketAddress> serverAddresses, Resolver resolver) {
+        init(serverAddresses, System.currentTimeMillis() ^ this.hashCode(), resolver);
+    }
+
+    /**
+     * Constructs a SimpleHostSet. This constructor is used from StaticHostProviderTest to produce deterministic test results
+     * by initializing sourceOfRandomness with the same seed
+     *
+     * @param serverAddresses
+     *            possibly unresolved ZooKeeper server addresses
+     * @param randomnessSeed a seed used to initialize sourceOfRandomnes
      * @throws IllegalArgumentException
      *             if serverAddresses is empty or resolves to an empty list
      */
-    public StaticHostProvider(Collection<InetSocketAddress> serverAddresses, Resolver resolver) {
-        this.resolver = resolver;
-        init(serverAddresses);
-    }
-
-    /**
-     * Common init method for all constructors.
-     * Resolve all unresolved server addresses, put them in a list and shuffle.
-     */
-    private void init(Collection<InetSocketAddress> serverAddresses) {
-        if (serverAddresses.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "A HostProvider may not be empty!");
-        }
-
-        this.serverAddresses.addAll(serverAddresses);
-        Collections.shuffle(this.serverAddresses);
-    }
-
-    /**
-     * Evaluate to a hostname if one is available and otherwise it returns the
-     * string representation of the IP address.
-     *
-     * In Java 7, we have a method getHostString, but earlier versions do not support it.
-     * This method is to provide a replacement for InetSocketAddress.getHostString().
-     *
-     * @param addr
-     * @return Hostname string of address parameter
-     */
-    private String getHostString(InetSocketAddress addr) {
-        String hostString = "";
-
-        if (addr == null) {
-            return hostString;
-        }
-        if (!addr.isUnresolved()) {
-            InetAddress ia = addr.getAddress();
-
-            // If the string starts with '/', then it has no hostname
-            // and we want to avoid the reverse lookup, so we return
-            // the string representation of the address.
-            if (ia.toString().startsWith("/")) {
-                hostString = ia.getHostAddress();
-            } else {
-                hostString = addr.getHostName();
+    public StaticHostProvider(Collection<InetSocketAddress> serverAddresses, long randomnessSeed) {
+        init(serverAddresses, randomnessSeed, new Resolver() {
+            @Override
+            public InetAddress[] getAllByName(String name) throws UnknownHostException {
+                return InetAddress.getAllByName(name);
             }
-        } else {
-            // According to the Java 6 documentation, if the hostname is
-            // unresolved, then the string before the colon is the hostname.
-            String addrString = addr.toString();
-            hostString = addrString.substring(0, addrString.lastIndexOf(':'));
-        }
-
-        return hostString;
+        });
     }
 
-    public int size() {
+    private void init(Collection<InetSocketAddress> serverAddresses, long randomnessSeed, Resolver resolver) {
+        this.sourceOfRandomness = new Random(randomnessSeed);
+        this.resolver = resolver;
+        if (serverAddresses.isEmpty()) {
+            throw new IllegalArgumentException("A HostProvider may not be empty!");
+        }
+        this.serverAddresses = shuffle(serverAddresses);
+        currentIndex = -1;
+        lastIndex = -1;
+    }
+
+    private InetSocketAddress resolve(InetSocketAddress address) {
+        try {
+            String curHostString = address.getHostString();
+            List<InetAddress> resolvedAddresses = new ArrayList<>(Arrays.asList(this.resolver.getAllByName(curHostString)));
+            if (resolvedAddresses.isEmpty()) {
+                return address;
+            }
+            Collections.shuffle(resolvedAddresses);
+            return new InetSocketAddress(resolvedAddresses.get(0), address.getPort());
+        } catch (UnknownHostException e) {
+            LOG.error("Unable to resolve address: {}", address.toString(), e);
+            return address;
+        }
+    }
+
+    private List<InetSocketAddress> shuffle(Collection<InetSocketAddress> serverAddresses) {
+        List<InetSocketAddress> tmpList = new ArrayList<>(serverAddresses.size());
+        tmpList.addAll(serverAddresses);
+        Collections.shuffle(tmpList, sourceOfRandomness);
+        return tmpList;
+    }
+
+    /**
+     * Update the list of servers. This returns true if changing connections is necessary for load-balancing, false
+     * otherwise. Changing connections is necessary if one of the following holds:
+     * a) the host to which this client is currently connected is not in serverAddresses.
+     *    Otherwise (if currentHost is in the new list serverAddresses):
+     * b) the number of servers in the cluster is increasing - in this case the load on currentHost should decrease,
+     *    which means that SOME of the clients connected to it will migrate to the new servers. The decision whether
+     *    this client migrates or not (i.e., whether true or false is returned) is probabilistic so that the expected
+     *    number of clients connected to each server is the same.
+     *
+     * If true is returned, the function sets pOld and pNew that correspond to the probability to migrate to ones of the
+     * new servers in serverAddresses or one of the old servers (migrating to one of the old servers is done only
+     * if our client's currentHost is not in serverAddresses). See nextHostInReconfigMode for the selection logic.
+     *
+     * See <a href="https://issues.apache.org/jira/browse/ZOOKEEPER-1355">ZOOKEEPER-1355</a>
+     * for the protocol and its evaluation, and StaticHostProviderTest for the tests that illustrate how load balancing
+     * works with this policy.
+     *
+     * @param serverAddresses new host list
+     * @param currentHost the host to which this client is currently connected
+     * @return true if changing connections is necessary for load-balancing, false otherwise
+     */
+    public synchronized boolean updateServerList(
+            Collection<InetSocketAddress> serverAddresses,
+            InetSocketAddress currentHost) {
+        List<InetSocketAddress> shuffledList = shuffle(serverAddresses);
+        if (shuffledList.isEmpty()) {
+            throw new IllegalArgumentException("A HostProvider may not be empty!");
+        }
+        // Check if client's current server is in the new list of servers
+        boolean myServerInNewConfig = false;
+
+        InetSocketAddress myServer = currentHost;
+
+        // choose "current" server according to the client rebalancing algorithm
+        if (reconfigMode) {
+            myServer = next(0);
+        }
+
+        // if the client is not currently connected to any server
+        if (myServer == null) {
+            // reconfigMode = false (next shouldn't return null).
+            if (lastIndex >= 0) {
+                // take the last server to which we were connected
+                myServer = this.serverAddresses.get(lastIndex);
+            } else {
+                // take the first server on the list
+                myServer = this.serverAddresses.get(0);
+            }
+        }
+
+        for (InetSocketAddress addr : shuffledList) {
+            if (addr.getPort() == myServer.getPort()
+                    && ((addr.getAddress() != null
+                    && myServer.getAddress() != null
+                    && addr.getAddress().equals(myServer.getAddress()))
+                    || addr.getHostString().equals(myServer.getHostString()))) {
+                myServerInNewConfig = true;
+                break;
+            }
+        }
+
+        reconfigMode = true;
+
+        newServers.clear();
+        oldServers.clear();
+        // Divide the new servers into oldServers that were in the previous list
+        // and newServers that were not in the previous list
+        for (InetSocketAddress address : shuffledList) {
+            if (this.serverAddresses.contains(address)) {
+                oldServers.add(address);
+            } else {
+                newServers.add(address);
+            }
+        }
+
+        int numOld = oldServers.size();
+        int numNew = newServers.size();
+
+        // number of servers increased
+        if (numOld + numNew > this.serverAddresses.size()) {
+            if (myServerInNewConfig) {
+                // my server is in new config, but load should be decreased.
+                // Need to decide if this client
+                // is moving to one of the new servers
+                if (sourceOfRandomness.nextFloat() <= (1 - ((float) this.serverAddresses.size()) / (numOld + numNew))) {
+                    pNew = 1;
+                    pOld = 0;
+                } else {
+                    // do nothing special - stay with the current server
+                    reconfigMode = false;
+                }
+            } else {
+                // my server is not in new config, and load on old servers must
+                // be decreased, so connect to
+                // one of the new servers
+                pNew = 1;
+                pOld = 0;
+            }
+        } else { // number of servers stayed the same or decreased
+            if (myServerInNewConfig) {
+                // my server is in new config, and load should be increased, so
+                // stay with this server and do nothing special
+                reconfigMode = false;
+            } else {
+                pOld = ((float) (numOld * (this.serverAddresses.size() - (numOld + numNew))))
+                        / ((numOld + numNew) * (this.serverAddresses.size() - numOld));
+                pNew = 1 - pOld;
+            }
+        }
+
+        if (!reconfigMode) {
+            currentIndex = shuffledList.indexOf(getServerAtCurrentIndex());
+        } else {
+            currentIndex = -1;
+        }
+        this.serverAddresses = shuffledList;
+        currentIndexOld = -1;
+        currentIndexNew = -1;
+        lastIndex = currentIndex;
+        return reconfigMode;
+    }
+
+    public synchronized InetSocketAddress getServerAtIndex(int i) {
+        if (i < 0 || i >= serverAddresses.size()) {
+            return null;
+        }
+        return serverAddresses.get(i);
+    }
+
+    public synchronized InetSocketAddress getServerAtCurrentIndex() {
+        return getServerAtIndex(currentIndex);
+    }
+
+    public synchronized int size() {
         return serverAddresses.size();
     }
 
+    /**
+     * Get the next server to connect to, when in "reconfigMode", which means that
+     * you've just updated the server list, and now trying to find some server to connect to.
+     * Once onConnected() is called, reconfigMode is set to false. Similarly, if we tried to connect
+     * to all servers in new config and failed, reconfigMode is set to false.
+     *
+     * While in reconfigMode, we should connect to a server in newServers with probability pNew and to servers in
+     * oldServers with probability pOld (which is just 1-pNew). If we tried out all servers in either oldServers
+     * or newServers we continue to try servers from the other set, regardless of pNew or pOld. If we tried all servers
+     * we give up and go back to the normal round robin mode
+     *
+     * When called, this should be protected by synchronized(this)
+     */
+    private InetSocketAddress nextHostInReconfigMode() {
+        boolean takeNew = (sourceOfRandomness.nextFloat() <= pNew);
+
+        // take one of the new servers if it is possible (there are still such
+        // servers we didn't try),
+        // and either the probability tells us to connect to one of the new
+        // servers or if we already
+        // tried all the old servers
+        if (((currentIndexNew + 1) < newServers.size()) && (takeNew || (currentIndexOld + 1) >= oldServers.size())) {
+            ++currentIndexNew;
+            return newServers.get(currentIndexNew);
+        }
+
+        // start taking old servers
+        if ((currentIndexOld + 1) < oldServers.size()) {
+            ++currentIndexOld;
+            return oldServers.get(currentIndexOld);
+        }
+
+        return null;
+    }
+
     public InetSocketAddress next(long spinDelay) {
-        currentIndex = ++currentIndex % serverAddresses.size();
-        if (currentIndex == lastIndex && spinDelay > 0) {
+        boolean needToSleep = false;
+        InetSocketAddress addr;
+
+        synchronized (this) {
+            if (reconfigMode) {
+                addr = nextHostInReconfigMode();
+                if (addr != null) {
+                    currentIndex = serverAddresses.indexOf(addr);
+                    return resolve(addr);
+                }
+                //tried all servers and couldn't connect
+                reconfigMode = false;
+                needToSleep = (spinDelay > 0);
+            }
+            ++currentIndex;
+            if (currentIndex == serverAddresses.size()) {
+                currentIndex = 0;
+            }
+            addr = serverAddresses.get(currentIndex);
+            needToSleep = needToSleep || (currentIndex == lastIndex && spinDelay > 0);
+            if (lastIndex == -1) {
+                // We don't want to sleep on the first ever connect attempt.
+                lastIndex = 0;
+            }
+        }
+        if (needToSleep) {
             try {
                 Thread.sleep(spinDelay);
             } catch (InterruptedException e) {
                 LOG.warn("Unexpected exception", e);
             }
-        } else if (lastIndex == -1) {
-            // We don't want to sleep on the first ever connect attempt.
-            lastIndex = 0;
         }
 
-        InetSocketAddress curAddr = serverAddresses.get(currentIndex);
-        try {
-            String curHostString = getHostString(curAddr);
-            List<InetAddress> resolvedAddresses = new ArrayList<InetAddress>(Arrays.asList(this.resolver.getAllByName(curHostString)));
-            if (resolvedAddresses.isEmpty()) {
-                return curAddr;
-            }
-            Collections.shuffle(resolvedAddresses);
-            return new InetSocketAddress(resolvedAddresses.get(0), curAddr.getPort());
-        } catch (UnknownHostException e) {
-            return curAddr;
-        }
+        return resolve(addr);
     }
 
-    @Override
-    public void onConnected() {
+    public synchronized void onConnected() {
         lastIndex = currentIndex;
+        reconfigMode = false;
     }
+
 }

--- a/zookeeper/pom.xml
+++ b/zookeeper/pom.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <!--
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements.  See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership.  The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+    -->
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper-parent</artifactId>
+        <version>3.4.14-swi1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <groupId>org.apache.zookeeper</groupId>
+    <artifactId>zookeeper</artifactId>
+    <packaging>jar</packaging>
+    <name>Zookeeper Combined Jar</name>
+    <description>Zookeeper Server Mono-jar</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper-server</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper-jute</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.yetus</groupId>
+            <artifactId>audience-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jline</groupId>
+            <artifactId>jline</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kerby</groupId>
+            <artifactId>kerb-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kerby</groupId>
+            <artifactId>kerb-simplekdc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kerby</groupId>
+            <artifactId>kerby-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-interceptor-kerberos</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-protocol-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-protocol-kerberos</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-ldif-partition</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-mavibot-partition</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-jdbm-partition</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-protocol-ldap</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.zookeeper:zookeeper-server</include>
+                                    <include>org.apache.zookeeper:zookeeper-jute</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>source-package</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <skipAssembly>true</skipAssembly>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/zookeeper/pom.xml
+++ b/zookeeper/pom.xml
@@ -66,10 +66,6 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.yetus</groupId>
             <artifactId>audience-annotations</artifactId>
         </dependency>


### PR DESCRIPTION
This review is the second swing at updating the Zookeeper 3.4.14 library to resolve the name resolver in JDK 13+ editions.

## Notes
The package build of the zookeeper doesn't create the unified zookeeper.jar needed for most projects, so I had to do some slice-and-dice on the maven to get things to build as intended. zookeeper.jar is build in a new zookeeper sub-module which contains zookeeper-jute, zookeeper-server, and the POM properly lists the dependencies of this unified jar.

## Caveats
I haven't tested the release build yet, as it will only be built on the `branch-3.4.14-swi` branch. There will likely be a small patch to resolve build issues on that effectively-master branch of this repo.